### PR TITLE
fix: trying to clarify usage of remotly used env vars

### DIFF
--- a/docs/further.md
+++ b/docs/further.md
@@ -18,12 +18,12 @@ shared-fs-usage:
   - source-cache
 ```
 
-If the shared scratch is e.g. specific for each job (e.g. controlled by a ``$JOBID``), one can define a job-specific local storage prefix like this
+If the shared scratch is e.g. specific for each job (e.g. controlled by a ``$JOBID``). Environment variables defined only on remote instances might need to be escaped (with a `\`) to prevent premature evaluation. One can define a job-specific local storage prefix like this
 
 ```yaml
 default-storage-provider: fs
 local-storage-prefix: /local/work/$USER
-remote-job-local-storage-prefix: /local/work/$USER/$JOBID
+remote-job-local-storage-prefix: /local/work/$USER/\$JOBID
 shared-fs-usage:
   - persistence
   - software-deployment


### PR DESCRIPTION
This mini-PR tries to emphasize the need to escape remote env variables. It addresses #28 . Whether it actually does the trick remains to be seen - when my cluster is accessible again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Refined explanatory text to improve clarity.
	- Updated configuration examples to ensure proper escaping of environment variables for accurate guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->