### PR TITLE
feat: on demand retrieval (via symlinking) in case input is annotated as on-demand eligible by Snakemake (e.g. because of sequential access being annotated by the developer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ keywords = ["snakemake", "plugin", "storage", "filesystem", "rsync"]
 [tool.poetry.dependencies]
 python = "^3.11"
 snakemake-interface-common = "^1.17.0"
-snakemake-interface-storage-plugins = "^4.0.1"
+snakemake-interface-storage-plugins = "^4.1.0"
 sysrsync = "^1.1.1"
 reretry = "^0.11.8"
 

--- a/snakemake_storage_plugin_fs/__init__.py
+++ b/snakemake_storage_plugin_fs/__init__.py
@@ -199,10 +199,20 @@ class StorageObject(
 
     def retrieve_object(self):
         # Ensure that the object is accessible locally under self.local_path()
-        cmd = sysrsync.get_rsync_command(
-            str(self.query_path), str(self.local_path()), options=["-av"]
-        )
-        self._run_cmd(cmd)
+        if self.is_ondemand_eligible:
+            self.provider.logger.info(
+                f"Creating symlink for on-demand retrieval of {self.query_path}."
+            )
+            os.symlink(
+                self.query_path,
+                self.local_path(),
+                target_is_directory=self.query_path.is_dir(),
+            )
+        else:
+            cmd = sysrsync.get_rsync_command(
+                str(self.query_path), str(self.local_path()), options=["-av"]
+            )
+            self._run_cmd(cmd)
 
     def store_object(self):
         # Ensure that the object is stored at the location specified by


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an on-demand file retrieval pathway that detects if a file qualifies for faster access.
	- For eligible files, the system now creates a link-based mechanism for quicker retrieval while retaining the standard method for others.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->